### PR TITLE
[GH-28] fix(Profile): add message and clear form on success

### DIFF
--- a/src/actorsScript/pages/Profile.tsx
+++ b/src/actorsScript/pages/Profile.tsx
@@ -1,30 +1,40 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from '../../redux/types';
-import { Button, Grid, TextField, Typography } from '@mui/material';
+import { Button, Grid, Typography } from '@mui/material';
 import { AuthLayout } from '../../auth/layout/AuthLayout';
 import { useFormValidation } from '../../auth/hooks/useFormValidation';
 import Loader from '../components/Loader';
 import { updatePassword } from '../../redux/thunks/authThunks';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { autoClearError } from '../../redux/slices/authSlice';
+import { PasswordField } from '../../components/PasswordField';
 
 export const Profile = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const { user } = useSelector((state: RootState) => state.auth);
-  const { validateForm, handleInputChange, formData, errors } =
+  const { validateForm, handleInputChange, formData, errors, resetForm } =
     useFormValidation({
       password: '',
       oldPassword: '',
       repeatPassword: ''
     });
   const { loading, error } = useSelector((state: RootState) => state.auth);
+  const [successMessage, setSuccessMessage] = useState('');
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validateForm()) return;
 
-    dispatch(updatePassword(formData));
+    const action = await dispatch(updatePassword(formData));
+    if (updatePassword.fulfilled.match(action)) {
+      resetForm();
+      setSuccessMessage('Contrasinal actualizado con éxito.');
+
+      setTimeout(() => {
+        setSuccessMessage('');
+      }, 4000);
+    }
   };
 
   useEffect(() => {
@@ -52,51 +62,39 @@ export const Profile = () => {
             }}
           >
             <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
-              <TextField
-                key="password"
+              <PasswordField
                 name="password"
-                label="novo contrasinal"
-                type="password"
-                placeholder="***********"
-                fullWidth
-                onChange={handleInputChange}
+                label="Novo contrasinal"
                 value={formData.password}
+                onChange={handleInputChange}
+                error={errors?.password}
+                placeholder="***********"
+                autoComplete="new-password"
               />
-              {errors?.password && (
-                <p className="error-message">{errors.password}</p>
-              )}
             </Grid>
 
             <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
-              <TextField
-                key="repeatPassword"
+              <PasswordField
                 name="repeatPassword"
-                label="repita o novo contrasinal"
-                type="password"
-                placeholder="***********"
-                fullWidth
-                onChange={handleInputChange}
+                label="Repita o novo contrasinal"
                 value={formData.repeatPassword}
+                onChange={handleInputChange}
+                error={errors?.repeatPassword}
+                placeholder="***********"
+                autoComplete="new-password"
               />
-              {errors?.repeatPassword && (
-                <p className="error-message">{errors.repeatPassword}</p>
-              )}
             </Grid>
 
             <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
-              <TextField
-                key="oldPassword"
+              <PasswordField
                 name="oldPassword"
-                label="contrasinal actual"
-                type="password"
-                placeholder="***********"
-                fullWidth
-                onChange={handleInputChange}
+                label="Contrasinal actual"
                 value={formData.oldPassword}
+                onChange={handleInputChange}
+                error={errors?.oldPassword}
+                placeholder="***********"
+                autoComplete="current-password"
               />
-              {errors?.oldPassword && (
-                <p className="error-message">{errors.oldPassword}</p>
-              )}
             </Grid>
 
             <Grid container spacing={2} size={{ xs: 12 }} sx={{ padding: 2 }}>
@@ -112,6 +110,9 @@ export const Profile = () => {
             </Grid>
           </Grid>
           {error && <p className="error-message fade-out4s">{error}</p>}
+          {successMessage && (
+            <p className="success-message fade-out4s">{successMessage}</p>
+          )}
         </form>
       </AuthLayout>
     </>

--- a/src/auth/hooks/useFormValidation.ts
+++ b/src/auth/hooks/useFormValidation.ts
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { isInjectionFree } from "../../utils/isInjectionFree";
-import { REGEX } from "../../constants";
+import { useState } from 'react';
+import { isInjectionFree } from '../../utils/isInjectionFree';
+import { REGEX } from '../../constants';
 
 export interface FormData {
   [key: string]: string;
@@ -11,15 +11,15 @@ export interface FormErrors {
 }
 
 export const useFormValidation = <
-  T extends Record<string, string | number | boolean | null | undefined>,
+  T extends Record<string, string | number | boolean | null | undefined>
 >(
-  initialFormData: T,
+  initialFormData: T
 ) => {
   const initialErrors: FormErrors = Object.keys(
-    initialFormData,
+    initialFormData
   ).reduce<FormErrors>(
-    (acc: FormErrors, key: string) => ({ ...acc, [key]: "" }),
-    {},
+    (acc: FormErrors, key: string) => ({ ...acc, [key]: '' }),
+    {}
   );
   const [formData, setFormData] = useState<T>(initialFormData);
   const [errors, setErrors] = useState<FormErrors>(initialErrors);
@@ -34,42 +34,42 @@ export const useFormValidation = <
   const validateField = (
     field: string,
     value: string | number | boolean | null | undefined,
-    newErrors: FormErrors,
+    newErrors: FormErrors
   ): boolean => {
     let valid = true;
 
-    if (typeof value === "string" && value.length > REGEX.maxInputLength) {
+    if (typeof value === 'string' && value.length > REGEX.maxInputLength) {
       newErrors[field] = `O valor excede ${REGEX.maxInputLength} caracteres.`;
       valid = false;
-    } else if (typeof value === "string" && !value.trim()) {
-      newErrors[field] = "É obrigatorio.";
+    } else if (typeof value === 'string' && !value.trim()) {
+      newErrors[field] = 'É obrigatorio.';
       valid = false;
-    } else if (typeof value === "string" && !isInjectionFree(value)) {
-      newErrors[field] = "Amodo oh! -9001";
+    } else if (typeof value === 'string' && !isInjectionFree(value)) {
+      newErrors[field] = 'Amodo oh! -9001';
       valid = false;
     } else if (
-      field === "email" &&
-      typeof value === "string" &&
+      field === 'email' &&
+      typeof value === 'string' &&
       !validateEmail(value)
     ) {
-      newErrors.email = "O correo non é válido.";
+      newErrors.email = 'O correo non é válido.';
       valid = false;
     } else if (
-      field === "password" &&
-      typeof value === "string" &&
+      field === 'password' &&
+      typeof value === 'string' &&
       !validatePassword(value)
     ) {
-      newErrors.password = "O contrasinal é feble.";
+      newErrors.password = 'O contrasinal é feble.';
       valid = false;
-    } else if (field === "repeatPassword" && value !== formData.password) {
-      newErrors.repeatPassword = "Os contrasinais non coinciden.";
+    } else if (field === 'repeatPassword' && value !== formData.password) {
+      newErrors.repeatPassword = 'Os contrasinais non coinciden.';
       valid = false;
     } else if (
-      field === "username" &&
-      typeof value === "string" &&
+      field === 'username' &&
+      typeof value === 'string' &&
       !REGEX.username.test(value)
     ) {
-      newErrors.username = "O nome de usuario non é válido.";
+      newErrors.username = 'O nome de usuario non é válido.';
       valid = false;
     }
 
@@ -92,10 +92,15 @@ export const useFormValidation = <
   };
 
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = ({
-    target: { name, value },
+    target: { name, value }
   }) => {
     setFormData((prev) => ({ ...prev, [name]: value }));
-    setErrors((prev) => ({ ...prev, [name]: "" }));
+    setErrors((prev) => ({ ...prev, [name]: '' }));
+  };
+
+  const resetForm = () => {
+    setFormData(initialFormData);
+    setErrors(initialErrors);
   };
 
   return {
@@ -105,5 +110,6 @@ export const useFormValidation = <
     setErrors,
     validateForm,
     handleInputChange,
+    resetForm
   };
 };

--- a/src/auth/pages/Login.tsx
+++ b/src/auth/pages/Login.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { autoClearError, } from "../../redux/slices/authSlice";
+import { Button, Grid, Link, TextField, Typography } from "@mui/material";
+import { Google } from "@mui/icons-material";
+import { autoClearError } from "../../redux/slices/authSlice";
 import Loader from "../../actorsScript/components/Loader";
+import { PasswordField } from "../../components/PasswordField";
 import { useFormValidation } from "../hooks/useFormValidation";
 import { AppDispatch, RootState } from "../../redux/types";
 import { loginUser } from "../../redux/thunks/authThunks";
 import { loginTranslationMap } from "../../i18n/translationMap";
 import { LoginPayload } from "../../redux/interfaces/authInterfaces";
-import { Button, Grid, Link, TextField, Typography } from "@mui/material";
-import { Link as RouterLink } from "react-router-dom";
-import { Google } from "@mui/icons-material";
 import { AuthLayout } from "../layout/AuthLayout";
 
 const Login = () => {
@@ -39,62 +40,64 @@ const Login = () => {
   }, [error, dispatch]);
 
   const currentLanguage = localStorage.getItem("language") ?? "es_gl";
-  const translationMap = loginTranslationMap[currentLanguage]
+  const translationMap = loginTranslationMap[currentLanguage];
 
   return (
-
     <AuthLayout title={translationMap.header}>
-      
       <form onSubmit={handleSubmit}>
-
         <Grid container alignItems={"center"} sx={{ border: "1px solid #e0e0e0", borderRadius: 2, padding: 2, mt: 2 }}>
-          <Grid size={{ xs: 12, }} sx={{ mt: 2 }}>
-            <TextField name="email" label={translationMap.email} type="email" placeholder="aaron@swartz.com" fullWidth autoComplete="username" value={formData.email} onChange={handleInputChange} />
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <TextField
+              name="email"
+              label={translationMap.email}
+              type="email"
+              placeholder="aaron@swartz.com"
+              fullWidth
+              autoComplete="username"
+              value={formData.email}
+              onChange={handleInputChange}
+            />
             {errors?.email && <p className="error-message">{errors.email}</p>}
           </Grid>
 
-          <Grid size={{ xs: 12, }} sx={{ mt: 2 }}>
-            <TextField name="password" label={translationMap.password} type="password" placeholder="***********" fullWidth autoComplete="current-password" value={formData.password} onChange={handleInputChange} />
-            {errors?.password && <p className="error-message">{errors.password}</p>}
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <PasswordField
+              name="password"
+              label={translationMap.password}
+              value={formData.password}
+              onChange={handleInputChange}
+              error={errors?.password}
+              placeholder="***********"
+              autoComplete="current-password"
+            />
           </Grid>
 
           <Grid container spacing={2} size={{ xs: 12 }} sx={{ mb: 2, padding: 2, mt: 2 }}>
             <Grid size={{ xs: 12, sm: 6 }} sx={{ mt: 2 }}>
-              <Button variant="contained" fullWidth disabled ><Google />
+              <Button variant="contained" fullWidth disabled>
+                <Google />
                 <Typography sx={{ ml: 1 }}>Google</Typography>
               </Button>
             </Grid>
 
             <Grid size={{ xs: 12, sm: 6 }} sx={{ mt: 2 }}>
-              {loading
-                ? <Loader />
-                : <Button variant="contained" fullWidth type="submit" >{translationMap.submit}</Button>}
+              {loading ? <Loader /> : <Button variant="contained" fullWidth type="submit">{translationMap.submit}</Button>}
             </Grid>
-
           </Grid>
 
           <Grid container size={{ xs: 12 }} direction="row" justifyContent="end" sx={{ mt: 2 }}>
             <Typography variant="body2" sx={{ color: 'primary.main', fontWeight: 'bold' }}>
               {translationMap.callToAction}
               <Link component={RouterLink} to="/register" sx={{ ml: 1, color: 'red', fontWeight: 'bold' }}>
-
                 {translationMap.action}
               </Link>
             </Typography>
           </Grid>
         </Grid>
 
-
-
-
-
-
         {error && <p className="error-message fade-out4s">{error}</p>}
       </form>
-
     </AuthLayout>
-
-
   );
 };
 

--- a/src/auth/pages/Register.tsx
+++ b/src/auth/pages/Register.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { Link as RouterLink } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
+import { Button, Grid, Link, TextField, Typography } from "@mui/material";
 import Loader from "../../actorsScript/components/Loader";
-import { useFormValidation } from "../hooks/useFormValidation";
+import { PasswordField } from "../../components/PasswordField";
 import { autoClearError } from "../../redux/slices/authSlice";
 import { AppDispatch, RootState } from "../../redux/types";
 import { registerUser } from "../../redux/thunks/authThunks";
 import { registerTranslationMap } from "../../i18n/translationMap";
+import { useFormValidation } from "../hooks/useFormValidation";
 import { AuthLayout } from "../layout/AuthLayout";
-import { Button, Grid, Link, TextField, Typography } from "@mui/material";
-import { Link as RouterLink } from "react-router-dom";
-
 
 export const Register = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -25,12 +25,13 @@ export const Register = () => {
     password: "",
     repeatPassword: "",
   });
+
   const { loading, error } = useSelector((state: RootState) => state.auth);
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validateForm()) return;
-
-    dispatch(registerUser({ id: uuidv4(), ...formData, }));
+    dispatch(registerUser({ id: uuidv4(), ...formData }));
   };
 
   useEffect(() => {
@@ -42,63 +43,83 @@ export const Register = () => {
   const currentLanguage = localStorage.getItem("language") ?? "es_gl";
   const translationMap = registerTranslationMap[currentLanguage];
 
-  const getInputType = (field: string): React.HTMLInputTypeAttribute | undefined => {
-    if (/password/i.test(field)) return "password";
-    return field === "email" ? "email" : "text";
-  };
-
-  const getAutocompleteProps = (field: string, isNewPassword: boolean) => {
-    let autoComplete: string;
-    if (field === "email") {
-      autoComplete = "username";
-    } else if (/password/i.test(field)) {
-      autoComplete = isNewPassword ? "new-password" : "current-password";
-    } else {
-      autoComplete = "off";
-    }
-
-
-    return autoComplete
-  }
-
-
   return (
     <AuthLayout title={translationMap.header}>
       <form onSubmit={handleSubmit} autoComplete="on">
         <Grid container alignItems={"center"} sx={{ border: "1px solid #e0e0e0", borderRadius: 2, padding: 2, mt: 2 }}>
-          {[["username", "aaron9000"], ["email", "aaron@swartz.op"], ["password", "********"], ["repeatPassword", "****"]].map(([field, placeholder]) => (
-            <Grid key={field} size={{ xs: 12, }} sx={{ mt: 2 }}>
-              <TextField name={field} label={translationMap[field as keyof typeof translationMap]} type={getInputType(field)} placeholder={placeholder} fullWidth value={formData[field as keyof typeof formData]} onChange={handleInputChange} autoComplete={
-                getAutocompleteProps(field, field === "password")
-              } />
-              {errors?.[field] && <p className="error-message">{errors[field]}</p>}
-            </Grid>
-          ))}
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <TextField
+              name="username"
+              label={translationMap.username}
+              placeholder="aaron9000"
+              fullWidth
+              value={formData.username}
+              onChange={handleInputChange}
+              autoComplete="off"
+            />
+            {errors?.username && <p className="error-message">{errors.username}</p>}
+          </Grid>
+
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <TextField
+              name="email"
+              label={translationMap.email}
+              placeholder="aaron@swartz.op"
+              fullWidth
+              value={formData.email}
+              onChange={handleInputChange}
+              autoComplete="username"
+            />
+            {errors?.email && <p className="error-message">{errors.email}</p>}
+          </Grid>
+
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <PasswordField
+              name="password"
+              label={translationMap.password}
+              placeholder="********"
+              value={formData.password}
+              onChange={handleInputChange}
+              error={errors?.password}
+              autoComplete="new-password"
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+            <PasswordField
+              name="repeatPassword"
+              label={translationMap.repeatPassword}
+              placeholder="********"
+              value={formData.repeatPassword}
+              onChange={handleInputChange}
+              error={errors?.repeatPassword}
+              autoComplete="new-password"
+            />
+          </Grid>
 
           <Grid container spacing={2} size={{ xs: 12 }} sx={{ mb: 2, padding: 2, mt: 2 }}>
             <Grid size={{ xs: 12, sm: 6 }} sx={{ mt: 2 }}>
-              {loading
-                ? <Loader />
-                : <Button variant="contained" fullWidth type="submit" >{translationMap.submit}</Button>}
+              {loading ? (
+                <Loader />
+              ) : (
+                <Button variant="contained" fullWidth type="submit">
+                  {translationMap.submit}
+                </Button>
+              )}
             </Grid>
-
           </Grid>
 
           <Grid container size={{ xs: 12 }} direction="row" justifyContent="end" sx={{ mt: 2 }}>
-            <Typography variant="body2" sx={{ color: 'primary.main', fontWeight: 'bold' }}>
+            <Typography variant="body2" sx={{ color: "primary.main", fontWeight: "bold" }}>
               {translationMap.callToAction}
-              <Link component={RouterLink} to="/login" sx={{ ml: 1, color: 'red', fontWeight: 'bold' }}>
-
+              <Link component={RouterLink} to="/login" sx={{ ml: 1, color: "red", fontWeight: "bold" }}>
                 {translationMap.action}
               </Link>
             </Typography>
           </Grid>
-
-
         </Grid>
         {error && <p className="error-message fade-out4s">{error}</p>}
       </form>
     </AuthLayout>
   );
 };
-

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { TextField, IconButton, InputAdornment } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+
+interface PasswordFieldProps {
+    name: string;
+    label: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    error?: string;
+    placeholder?: string;
+    autoComplete?: string;
+}
+
+export const PasswordField: React.FC<PasswordFieldProps> = ({
+    name,
+    label,
+    value,
+    onChange,
+    error,
+    placeholder,
+    autoComplete,
+}) => {
+    const [visible, setVisible] = useState(false);
+
+    const handleMouseDown = () => setVisible(true);
+    const handleMouseUp = () => setVisible(false);
+
+    return (
+        <>
+            <TextField
+                name={name}
+                label={label}
+                type={visible ? "text" : "password"}
+                value={value}
+                onChange={onChange}
+                fullWidth
+                placeholder={placeholder}
+                autoComplete={autoComplete}
+                error={!!error}
+                slotProps={{
+                    input: {
+                        endAdornment: (
+                            <InputAdornment position="end">
+                                <IconButton
+                                    edge="end"
+                                    onMouseDown={handleMouseDown}
+                                    onMouseUp={handleMouseUp}
+                                    onMouseLeave={handleMouseUp}
+                                    onTouchStart={handleMouseDown}
+                                    onTouchEnd={handleMouseUp}
+                                >
+                                    {visible ? <VisibilityOff /> : <Visibility />}
+                                </IconButton>
+                            </InputAdornment>
+                        ),
+                    },
+                }}
+            />
+            {error && <p className="error-message">{error}</p>}
+        </>
+    );
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,9 @@ body {
 .error-message {
   color: red;
 }
+.success-message {
+  color: green;
+}
 
 .small {
   font-size: 0.8rem;

--- a/tests/Pages/Register.test.tsx
+++ b/tests/Pages/Register.test.tsx
@@ -65,7 +65,8 @@ describe("Register Page", () => {
     labels.forEach((label) => {
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
-    expect(screen.getByRole("button")).toHaveTextContent("Rexístrate");
+    expect(screen.getByRole("button", { name: "Rexístrate" })).toBeInTheDocument();
+
   });
 
   it("should display validation errors when form is submitted with invalid data", async () => {
@@ -73,7 +74,7 @@ describe("Register Page", () => {
 
     renderWithProvider(store);
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     errorMessages.forEach((message) => {
@@ -92,7 +93,7 @@ describe("Register Page", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(dispatchSpy).toHaveBeenCalled();
@@ -105,7 +106,7 @@ describe("Register Page", () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(screen.getByText("O correo non é válido.")).toBeInTheDocument();
@@ -121,7 +122,7 @@ describe("Register Page", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(
@@ -131,12 +132,12 @@ describe("Register Page", () => {
 
   it("should display error message when password is invalid", async () => {
     renderWithProvider(store);
-    fireEvent.change(screen.getByPlaceholderText("********"), {
+    fireEvent.change(screen.getByLabelText("Contrasinal"), {
       target: { value: "password" },
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(screen.getByText("O contrasinal é feble.")).toBeInTheDocument();
@@ -152,7 +153,7 @@ describe("Register Page", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(
@@ -171,7 +172,7 @@ describe("Register Page", () => {
       fillRegisterForm("testUser", "das@das.com", inj, "Password.123");
 
       await act(async () => {
-        fireEvent.click(screen.getByRole("button"));
+        fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
       });
 
       expect(screen.getByText("Amodo oh! -9001")).toBeInTheDocument();
@@ -183,7 +184,7 @@ describe("Register Page", () => {
     fillRegisterForm("TestUser", "te@dsa.com", "Password.123", "Password.123");
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button", { name: "Rexístrate" }));
     });
 
     expect(screen.queryByText("BackEndError")).toBeInTheDocument();

--- a/tests/actorsScript/pages/Profile.test.tsx
+++ b/tests/actorsScript/pages/Profile.test.tsx
@@ -22,13 +22,13 @@ const fillForm = (
   repeatPassword: string,
   oldPassword: string
 ) => {
-  fireEvent.change(screen.getByLabelText('novo contrasinal'), {
+  fireEvent.change(screen.getByLabelText('Novo contrasinal'), {
     target: { value: newPassword }
   });
-  fireEvent.change(screen.getByLabelText('repita o novo contrasinal'), {
+  fireEvent.change(screen.getByLabelText('Repita o novo contrasinal'), {
     target: { value: repeatPassword }
   });
-  fireEvent.change(screen.getByLabelText('contrasinal actual'), {
+  fireEvent.change(screen.getByLabelText('Contrasinal actual'), {
     target: { value: oldPassword }
   });
 };
@@ -65,11 +65,11 @@ describe('Profile', () => {
   it('should render the update password form', () => {
     renderWithProvider(store);
 
-    expect(screen.getByLabelText('novo contrasinal')).toBeInTheDocument();
+    expect(screen.getByLabelText('Novo contrasinal')).toBeInTheDocument();
     expect(
-      screen.getByLabelText('repita o novo contrasinal')
+      screen.getByLabelText('Repita o novo contrasinal')
     ).toBeInTheDocument();
-    expect(screen.getByLabelText('contrasinal actual')).toBeInTheDocument();
+    expect(screen.getByLabelText('Contrasinal actual')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Actualizar' })
     ).toBeInTheDocument();

--- a/tests/components/PasswordField.test.tsx
+++ b/tests/components/PasswordField.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { PasswordField } from "../../src/components/PasswordField";
+
+describe("PasswordField Component", () => {
+    const defaultProps = {
+        name: "password",
+        label: "Password",
+        value: "",
+        onChange: jest.fn(),
+        error: "",
+        placeholder: "Enter your password",
+        autoComplete: "off",
+    };
+
+    it("renders the PasswordField component", () => {
+        render(<PasswordField {...defaultProps} />);
+
+        expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    });
+
+    it("toggles password visibility on icon button click", async () => {
+        render(<PasswordField {...defaultProps} />);
+        const input = screen.getByLabelText("Password");
+        const toggleButton = screen.getByRole("button");
+
+        expect(input).toHaveAttribute("type", "password");
+
+        act(() => {
+            fireEvent.mouseDown(toggleButton);
+        });
+        await waitFor(() => {
+            expect(input).toHaveAttribute("type", "text");
+        });
+
+        act(() => {
+            fireEvent.mouseUp(toggleButton);
+        });
+        await waitFor(() => {
+            expect(input).toHaveAttribute("type", "password");
+        });
+    });
+
+    it("displays an error message when error prop is provided", () => {
+        const errorMessage = "Password is required";
+
+        render(<PasswordField {...defaultProps} error={errorMessage} />);
+
+        expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    it("calls onChange handler when input value changes", () => {
+        render(<PasswordField {...defaultProps} />);
+        const input = screen.getByLabelText("Password");
+
+        fireEvent.change(input, { target: { value: "new-password" } });
+
+        expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
feat: enhance profile page with password update functionality and success message
feat: create reusable PasswordField component for password input
fix: update validation messages and improve accessibility in forms
style: update CSS for success message styling
test: add tests for PasswordField component and update Profile tests for label changes